### PR TITLE
qpnp-haptic: make its strength adjustable in VibratorHW

### DIFF
--- a/drivers/soc/qcom/qpnp-haptic.c
+++ b/drivers/soc/qcom/qpnp-haptic.c
@@ -302,6 +302,7 @@ struct qpnp_hap {
 	enum qpnp_hap_high_z		lra_high_z;
 	u32				timeout_ms;
 	u32				vmax_mv;
+	u32				vmax_default_mv;
 	u32				vmax_percent;
 	u32				ilim_ma;
 	u32				sc_deb_cycles;
@@ -1135,6 +1136,28 @@ static ssize_t qpnp_hap_vmax_mv_strong_store(struct device *dev,
 	return count;
 }
 
+static ssize_t qpnp_hap_vmax_default(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	struct timed_output_dev *timed_dev = dev_get_drvdata(dev);
+	struct qpnp_hap *hap = container_of(timed_dev, struct qpnp_hap,
+					 timed_dev);
+
+	return snprintf(buf, PAGE_SIZE, "%d\n", hap->vmax_default_mv);
+}
+
+static ssize_t qpnp_hap_vmax_max(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, PAGE_SIZE, "%d\n", QPNP_HAP_VMAX_MAX_MV);
+}
+
+static ssize_t qpnp_hap_vmax_min(struct device *dev,
+		struct device_attribute *attr, char *buf)
+{
+	return snprintf(buf, PAGE_SIZE, "%d\n", QPNP_HAP_VMAX_MIN_MV);
+}
+
 /* sysfs show for wave form update */
 static ssize_t qpnp_hap_wf_update_show(struct device *dev,
 		struct device_attribute *attr, char *buf)
@@ -1451,6 +1474,10 @@ static struct device_attribute qpnp_hap_attrs[] = {
 	__ATTR(vmax_mv_strong, (S_IRUGO | S_IWUSR | S_IWGRP),
 			qpnp_hap_vmax_mv_strong_show,
 			qpnp_hap_vmax_mv_strong_store),
+	__ATTR(vtg_level, (S_IRUGO | S_IWUSR), qpnp_hap_vmax_show, qpnp_hap_vmax_store),
+	__ATTR(vtg_default, S_IRUGO, qpnp_hap_vmax_default, NULL),
+	__ATTR(vtg_max, S_IRUGO, qpnp_hap_vmax_max, NULL),
+	__ATTR(vtg_min, S_IRUGO, qpnp_hap_vmax_min, NULL),
 	__ATTR(wf_s0, 0664, qpnp_hap_wf_s0_show, qpnp_hap_wf_s0_store),
 	__ATTR(wf_s1, 0664, qpnp_hap_wf_s1_show, qpnp_hap_wf_s1_store),
 	__ATTR(wf_s2, 0664, qpnp_hap_wf_s2_show, qpnp_hap_wf_s2_store),
@@ -2262,9 +2289,11 @@ static int qpnp_hap_parse_dt(struct qpnp_hap *hap)
 	}
 
 	hap->vmax_mv = QPNP_HAP_VMAX_MAX_MV;
+	hap->vmax_default_mv = QPNP_HAP_VMAX_MAX_MV;
 	rc = of_property_read_u32(pdev->dev.of_node, "qcom,vmax-mv", &temp);
 	if (!rc) {
 		hap->vmax_mv = temp;
+		hap->vmax_default_mv = temp;
 	} else if (rc != -EINVAL) {
 		dev_err(&pdev->dev, "Unable to read vmax\n");
 		return rc;


### PR DESCRIPTION
LineageOS has it own interface for vibration strength control. This change enables LineageOS and Resurrection Remix to change vibration strength from Settings.

This was original cherry picked from
https://github.com/LineageOS/android_kernel_oneplus_msm8998/commit/10774170951d1792735794638011aec61eabe57a
But made the changes into qpnp-haptic.c instead of qpnp-haptic_oem.c.